### PR TITLE
add SIGTERM signal to apis images so gunicorn can gracefully shutdown

### DIFF
--- a/auth/Dockerfile
+++ b/auth/Dockerfile
@@ -13,4 +13,6 @@ EXPOSE 5000
 ENV FLASK_APP=app.py
 ENV FLASK_DEBUG=1
 
+STOPSIGNAL SIGTERM
+
 ENTRYPOINT [ "gunicorn", "--log-level", "debug", "--graceful-timeout", "30", "--bind", "0.0.0.0:5000", "app:app" ]

--- a/authors/Dockerfile
+++ b/authors/Dockerfile
@@ -13,4 +13,6 @@ EXPOSE 5000
 ENV FLASK_APP=app.py
 ENV FLASK_DEBUG=1
 
+STOPSIGNAL SIGTERM
+
 ENTRYPOINT [ "gunicorn", "--log-level", "debug", "--graceful-timeout", "30", "--bind", "0.0.0.0:5000", "app:app" ]


### PR DESCRIPTION
add SIGTERM signal to apis images so gunicorn can gracefully shutdown when maneged by most popular orchestrators or when sent specific signal with `docker kill --signal="SIGTERM" <container-name>`